### PR TITLE
hl/redraw fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ require("artio").setup({
   },
 })
 
--- this is needed to avoid racing with extui when use `opts.bottom=true`
-vim.o.showmode = false
-
 -- override built-in ui select with artio
 vim.ui.select = require("artio").select
 


### PR DESCRIPTION
fix: set hls on `UIEnter`

set highlights when colorscheme is already set before the plugin is loaded.