### PR TITLE
feat(plugin): user command param fuzzy matching

### DIFF
--- a/plugin/artio.lua
+++ b/plugin/artio.lua
@@ -46,8 +46,9 @@ vim.api.nvim_create_user_command("Artio", function(opts)
   builtin()
 end, {
   nargs = "?",
-  complete = function(_, _, _)
-    return vim.tbl_keys(require("artio.builtins"))
+  complete = function(argLead)
+    local builtins = vim.tbl_keys(require("artio.builtins"))
+    return vim.fn.matchfuzzy(builtins, argLead)
   end,
 })
 


### PR DESCRIPTION
The completion which existed always showed the complete list of
artio.builtins and didn't use what the documentation calls the leading
portion (argLead) of the argument currently being completed on. This
uses the argLead with fuzzy matching.
