### PR TITLE
feat: add preview to helptags

### DIFF
--- a/lua/artio/builtins.lua
+++ b/lua/artio/builtins.lua
@@ -272,6 +272,17 @@ builtins.helptags = function(props)
           vim.cmd.help(text)
         end)
       end,
+      preview_item = function(tag)
+        return vim.api.nvim_create_buf(false, true), function(w)
+          local buf = vim.api.nvim_win_get_buf(w)
+          vim.bo[buf].bufhidden = "wipe"
+          vim.bo[buf].buftype = "help"
+
+          vim._with({ buf = buf }, function()
+            vim.cmd.help(tag)
+          end)
+        end
+      end,
     }, props)
   )
 end


### PR DESCRIPTION
builtin helptags did not have a preview window, but it can be useful to better narrow down which tag the user is looking for